### PR TITLE
fixed output of check and in cmds to avoid error message

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -1,11 +1,23 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
-	"fmt"
+	"strconv"
 	"time"
 )
 
+type Version struct {
+	Ref string `json:"ref"`
+}
+
+type Versions []Version
+
 func main() {
-	os.Stdout.Write([]byte(fmt.Sprintf("{ \"version\" :{ \"ref\" :\"%d\"}}", time.Now().Unix())))
+	versions := Versions{}
+	version := Version{
+		Ref: strconv.FormatInt(time.Now().Unix(), 10),
+	}
+	versions = append(versions, version)
+	json.NewEncoder(os.Stdout).Encode(versions)
 }

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -1,11 +1,23 @@
 package main
 
 import (
-	"fmt"
+	"encoding/json"
 	"os"
+	"strconv"
 	"time"
 )
 
+type Version struct {
+	Ref string `json:"ref"`
+}
+
+type Versions []Version
+
 func main() {
-	os.Stdout.Write([]byte(fmt.Sprintf("{ \"version\" :{ \"ref\" :\"%d\"}}", time.Now().Unix())))
+	versions := Versions{}
+	version := Version{
+		Ref: strconv.FormatInt(time.Now().Unix(), 10),
+	}
+	versions = append(versions, version)
+	json.NewEncoder(os.Stdout).Encode(versions)
 }


### PR DESCRIPTION
This is to resolve the error:
```
json: cannot unmarshal object into Go value of type []atc.Version
```
when the flowdock-notification resource runs the `check` command.

Changed `in` command to do the same.