### PR TITLE
fixed resource versioning

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"encoding/json"
 	"os"
-	"strconv"
-	"time"
 )
 
 type Version struct {
@@ -15,9 +13,5 @@ type Versions []Version
 
 func main() {
 	versions := Versions{}
-	version := Version{
-		Ref: strconv.FormatInt(time.Now().Unix(), 10),
-	}
-	versions = append(versions, version)
 	json.NewEncoder(os.Stdout).Encode(versions)
 }

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -3,9 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 )
 
 func main() {
-	os.Stdout.Write([]byte(fmt.Sprintf("{ \"version\" :{ \"ref\" :\"%d\"}}", time.Now().Unix())))
+	os.Stdout.Write([]byte(fmt.Sprintf("{ \"version\" :{ \"ref\" :\"none\"}}")))
 }

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"net/http"
 	"bytes"
-	"time"
 )
 
 func metadataMap() []map[string]string {
@@ -161,7 +160,7 @@ func main() {
 	}
 
 	sendRequest(requestUrl, requestData)
-	os.Stdout.Write([]byte(fmt.Sprintf("{ \"version\" :{ \"ref\" :\"%d\"}}", time.Now().Unix())))
+	os.Stdout.Write([]byte(fmt.Sprintf("{ \"version\" :{ \"ref\" :\"%s\"}}", input.Params.StatusValue)))
 }
 
 type Resource struct {


### PR DESCRIPTION
Previously, the `in` and `check` commands return current timestamp which creates a new version for the resource which is unnecessary.

Also, `out` command is changed to show the status param instead of current timestamp.