### PR TITLE
Added curl install to accommodate rest API commands where helpful

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR github.com/rafikn/flowdock-notification-resource
 FROM alpine:edge AS resource
 
 RUN apk add --update --no-cache ca-certificates
+RUN apk add curl
 
 COPY --from=builder assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
-


### PR DESCRIPTION
Adding curl to the flowdock-notification-resource. This is primarily to support concourse workflows where we need to send curl commands to the flowdock message api e.g. to invoke Rex. Any image containing curl would work for that use-case but I think contextually this makes the most sense. 